### PR TITLE
Remove devDependencies from package.json prior to publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "test": "./node_modules/.bin/karma start",
     "travis": "./node_modules/.bin/karma start ./karma.conf.travis.js",
-    "table": "node ./cli/index.js results/libs/*.json"
+    "table": "node ./cli/index.js results/libs/*.json",
+    "prepublish": "json -f package.json -I -e 'delete this.devDependencies'"
   },
   "repository": {
     "type": "git",
@@ -32,6 +33,7 @@
     "faster-stable-stringify": "^1.0.0",
     "fs-extra": "^4.0.1",
     "glob": "^7.1.2",
+    "json": "^9.0.6",
     "json-stable-stringify": "^1.0.0",
     "karma": "^1.7.1",
     "karma-benchmark": "^0.7.1",


### PR DESCRIPTION
Make sure you are working on a green git before running npm publish!

# Issue
None of the dev dependencies on this project are actually needed if it is
used as a library. Therefore, remove dev dependencies prior to publishing
to NPM makes sure that this library does not polute peoples node_modules
with unneeded downloads and libraries.

For example, there is not need to install json-stable-stringify, or karma
or webpack, for using this as a third party.

Please note that running npm publish after this commit will overwrite
your package.json locally.